### PR TITLE
Material palette link fix

### DIFF
--- a/session13-Android/README.md
+++ b/session13-Android/README.md
@@ -2,7 +2,7 @@
 
 ## Tip:
 Voor iedereen die verantwoord kleurgebruik leuk vindt en geen tijd:
-een Material Design palette generator [www.materialpalette.com/](www.materialpalette.com/)
+een Material Design palette generator [www.materialpalette.com/](http://www.materialpalette.com/)
 
 ## Voorbereiding 1: Video’s kijken
 


### PR DESCRIPTION
De link naar de material palette website verwees naar [https://github.com/HANICA/mad-1/blob/master/session13-Android/www.materialpalette.com](https://github.com/HANICA/mad-1/blob/master/session13-Android/www.materialpalette.com) omdat er geen http:// voor stond